### PR TITLE
Tirei o campo senha da busca de policiais

### DIFF
--- a/api/src/controllers/policial.js
+++ b/api/src/controllers/policial.js
@@ -123,7 +123,7 @@ class PolicialController {
         const httpHelper = new HttpHelper(response);
         try {
             const policiais = await PolicialModel.findAll({
-                order: [["matricula_policial", "ASC"]],
+                order: [["matricula_policial", "ASC"]], attributes: { exclude: ["senha"]}
             });
 
             return httpHelper.ok(policiais);
@@ -152,7 +152,7 @@ class PolicialController {
                     unidade_policia: {
                         [Op.like]: `%${request.body.unidade_policia}%`
                     }
-                },
+                }, attributes: { exclude: ["senha"]}
             });
 
             return httpHelper.ok(policiais);


### PR DESCRIPTION
No controller de policial, nos métodos "getAll" e "getFilter" adicionei um atributtes para remover o campo 'senha' da query.